### PR TITLE
Implement phase-one systemic foundations

### DIFF
--- a/balance_review.md
+++ b/balance_review.md
@@ -1,0 +1,85 @@
+# Nightmare Shift Balance Review & Rule Rework Proposal
+
+## 1. Executive Summary
+Nightmare Shift already sells the fantasy of a midnight cabbie navigating supernatural fares, but the current balance leans too heavily on binary "obey or die" rules. Because the safest option is to follow every shift regulation, players default to conservative play, runs feel samey, and iconic moments (like a starving vampire begging for a shortcut) rarely emerge. The solution is not to discard the rules, but to reinterpret them as *shift guidelines* that normally keep you safe yet occasionally demand calculated violations. This review outlines how to rebalance shift pacing, passenger behaviors, and resource pressure so that evaluating when to break protocol becomes the heart of the experience.
+
+## 2. Current Balance Pain Points
+1. **Binary rule outcomes** – Violating a rule almost always triggers instant failure, so players never experiment.
+2. **Flat passenger states** – Riders seldom broadcast evolving needs (hunger, fear, rage), leaving no justification to bend the rules.
+3. **Pacing cliffs** – Early shifts introduce harsh penalties before players gather information, while late shifts lack escalation.
+4. **Single-resource pressure** – Fuel and cash are the only levers; there is no risk trade-off beyond raw survival.
+5. **Limited rule interplay** – Rules operate independently, so players rarely face situations where obeying one breaks another.
+6. **Weak feedback loops** – Successful improvisation earns little more than narrative flavor, so optimal play stays conservative.
+
+## 3. Shift Rule Reframe: Defaults vs. Exceptions
+Transform the rulebook into a living document the player interrogates each night.
+
+| Rule | Default Benefit | Exception Trigger | Player Tells | Reward for Correct Break |
+|------|-----------------|-------------------|--------------|-------------------------|
+| Always follow dispatch routes | Reduced ambush chance | Time-sensitive fares (e.g., hungry vampire) | Passenger watches clock, fangs elongate, window frost forming | Bonus pay + "trust" buff for nocturnal passengers |
+| Never engage mirrors | Prevents reflective entities from entering cab | Passengers with cursed reflections who need the mirror exposed | Passenger covers mirror, reflection lags, shadow begs for light | Protective charm, unlocks mirror lore |
+| Maintain eyes on the road | Avoids enthrallment | Lonely spirits spiral if ignored | Audio cues of sobbing, steering wheel vibrating | Humanity/stress reduction, unlock dialogue |
+| Keep windows sealed | Blocks whispers | Suffocating or sunlight-sensitive passengers | Fogging glass, breathing difficulty, UV talisman glowing | Reputation bonus with daylight factions |
+| Respect fare limits (no free rides) | Sustains income loop | Destitute souls require charity | Passenger produces worthless currency, recounts tragedy | Unlocks rare narrative route, future discounts |
+
+*Design Notes*
+- Communicate exceptions via escalating tells (visual/audio/UI) over 2–3 beats to allow player inference.
+- Apply weighted randomization so the same passenger can be genuine or manipulative across runs.
+- Track player "Rule Confidence" that adjusts the chance of tells being truthful. Breaking rules recklessly lowers it; successful reads raise it.
+
+## 4. Passenger State Model
+Introduce lightweight state machines per archetype:
+- **Need Meter**: Hunger, fear, wrath, decay, etc. Rising meters unlock exception requests.
+- **Stability Threshold**: When need is critical, following the default rule becomes dangerous.
+- **Masking Behavior**: Some passengers hide their need until the player violates or obeys a rule, enabling bluffing scenarios.
+
+*Example – The Famished Vampire*
+- Starts calm (Need 2/5). Prefers normal speed (rule: obey speed limit).
+- At Need 4/5, fangs emerge, dialogue shifts to curt demands. If player keeps obeying dispatch route, vampire lunges (instant fail).
+- If player takes shortcut (rule break), vampire regains composure, pays double, leaves a blood ward item.
+
+## 5. Shift Pacing & Difficulty Curve
+1. **Opening Rides (Tutorial Beats)**
+   - Guarantee obvious tells and low penalty for experimentation.
+   - Provide dispatcher tips hinting that rules have exceptions.
+2. **Mid-Shift (Tension Plateau)**
+   - Mix truthful and deceptive tells (60/40). Introduce conflicting rules (e.g., keep windows closed vs. passenger demanding fresh air).
+   - Unlock mid-tier items (sigils, charms) that buffer failures but add upkeep.
+3. **Final Stretch (High Stakes)**
+   - Add "Shift Anomalies" that globally alter rules (e.g., "All mirrors show lies tonight").
+   - Increase frequency of compound dilemmas where obeying one rule breaks another, forcing prioritization.
+
+## 6. Resource & Economy Adjustments
+- **Humanity / Stress Meter**: Dropping too low triggers involuntary rule breaks or hallucinations. Successful exceptions replenish humanity.
+- **Passenger Trust**: Tracks goodwill. Higher trust lowers fare refusal penalties and unlocks rule hints.
+- **Nightly Quotas**: Instead of a flat cash minimum, combine cash + trust + humanity targets to pass the shift.
+- **Consumable Prep**: Pre-shift loadout choices (charms, snacks, music) trade cash for safety nets, encouraging different playstyles.
+
+## 7. Feedback & Progression Rewards
+- **Rule Ledger UI**: After each ride, log which rules were bent, whether the call was correct, and the outcome.
+- **Dispatcher Debrief**: Provide graded feedback (letters or narrative notes) tied to bonuses or new guidelines.
+- **Unlockable Alternate Rules**: Mastering exceptions unlocks advanced rules ("On Blood Moons, reverse the order of introductions"), adding replay depth.
+- **Narrative Payoffs**: Successful exception handling should gate unique stories, items, and endings so optimal play includes calculated risk.
+
+## 8. Implementation Roadmap
+1. **Phase 1 – System Foundations**
+   - Convert static rules into data-driven entries with fields for defaults, exceptions, tells, rewards.
+   - Build passenger state machines and hook them into dialogue generators.
+   - Add Rule Confidence and Need meters to core game state.
+2. **Phase 2 – Content Authoring**
+   - Author 3–4 exception scenarios per rule with unique narrative beats.
+   - Layer in audio/visual cues for each tell tier.
+   - Design economy tweaks (humanity, trust) and adjust shift success formula.
+3. **Phase 3 – Balancing & QA**
+   - Instrument analytics to track rule obedience vs. exceptions and resulting survival.
+   - Run targeted playtests focusing on clarity of tells and fairness of exceptions.
+   - Iterate on reward payouts so successful improvisation feels materially valuable.
+
+## 9. Success Metrics
+- ≥60% of completed runs include at least one intentional rule break.
+- Players report (survey/NPS) that "reading passengers" is the primary tension driver.
+- Survival rate remains within desired range (30–40%) despite increased experimentation.
+- Repeat players encounter at least one new exception scenario within their first three subsequent runs.
+
+---
+Balancing Nightmare Shift around *when* to break the rules—rather than whether to break them—turns every fare into a tense negotiation. By giving passengers evolving needs, telegraphed tells, and meaningful rewards for smart risk, we can ensure moments like racing a hungry vampire through red lights feel not only justified, but inevitable.

--- a/frontend/src/data/gameData.ts
+++ b/frontend/src/data/gameData.ts
@@ -1,4 +1,32 @@
-import type { GameData } from '../types/game';
+import type {
+  GameData,
+  GuidelineException
+} from '../types/game';
+import { guidelineData } from './guidelineData';
+
+const guidelineExceptionIndex = new Map<string, GuidelineException>();
+
+guidelineData.forEach(guideline => {
+  guideline.exceptions.forEach(exception => {
+    guidelineExceptionIndex.set(exception.id, exception);
+  });
+});
+
+const cloneGuidelineException = (exceptionId: string): GuidelineException | null => {
+  const exception = guidelineExceptionIndex.get(exceptionId);
+  if (!exception) return null;
+
+  return {
+    ...exception,
+    conditions: exception.conditions.map(condition => ({ ...condition })),
+    tells: exception.tells.map(tell => ({ ...tell }))
+  };
+};
+
+const getExceptions = (exceptionIds: string[]): GuidelineException[] =>
+  exceptionIds
+    .map(id => cloneGuidelineException(id))
+    .filter((exception): exception is GuidelineException => exception !== null);
 
 // Complete game data including rules, passengers, and locations
 export const gameData: GameData = {
@@ -10,15 +38,101 @@ export const gameData: GameData = {
       description: "Do not look directly at passengers tonight",
       difficulty: "medium",
       type: "basic",
-      visible: true
+      visible: true,
+      actionKey: 'eye_contact',
+      actionType: 'forbidden',
+      relatedGuidelineId: 1001,
+      defaultSafety: 'safe',
+      defaultOutcome: 'Averting your gaze keeps predatory spirits at bay and maintains cab stability.',
+      exceptions: getExceptions(['eye_contact_lonely']),
+      followConsequences: [
+        {
+          type: 'survival',
+          value: 1,
+          description: 'You resisted the passenger\'s pull and finished the ride unharmed.',
+          probability: 0.85
+        }
+      ],
+      breakConsequences: [
+        {
+          type: 'death',
+          value: 1,
+          description: 'Staring into a void-touched passenger shredded your sense of self.',
+          probability: 0.7
+        }
+      ],
+      exceptionRewards: [
+        {
+          type: 'reputation',
+          value: 8,
+          description: 'Acknowledged a lonely spirit and earned supernatural goodwill.',
+          probability: 0.75
+        },
+        {
+          type: 'story_unlock',
+          value: 1,
+          description: 'Unlocked a heartfelt confession that opens a new narrative thread.',
+          probability: 0.5
+        }
+      ],
+      exceptionNeedAdjustment: -25,
+      followNeedAdjustment: 5,
+      breakNeedAdjustment: 15,
+      violationMessage: 'You locked eyes when you were warned not to. Something inside you unraveled.'
     },
     {
-      id: 2, 
+      id: 2,
       title: "Silent Night",
       description: "No radio or music allowed during rides",
       difficulty: "easy",
       type: "basic",
-      visible: true
+      visible: true,
+      actionKey: 'play_music',
+      actionType: 'forbidden',
+      relatedGuidelineId: 1011,
+      defaultSafety: 'safe',
+      defaultOutcome: 'Maintaining silence prevents the radio frequencies from attracting spirits.',
+      exceptions: getExceptions(['silent_soothing_song']),
+      followConsequences: [
+        {
+          type: 'survival',
+          value: 1,
+          description: 'Kept the cab quiet and avoided spectral interference.',
+          probability: 0.8
+        }
+      ],
+      breakConsequences: [
+        {
+          type: 'death',
+          value: 1,
+          description: 'The song acted as a beacon for the wrong audience.',
+          probability: 0.4
+        },
+        {
+          type: 'fuel',
+          value: -5,
+          description: 'Equipment interference drained your cab\'s power.',
+          probability: 0.5
+        }
+      ],
+      exceptionRewards: [
+        {
+          type: 'reputation',
+          value: 6,
+          description: 'Calmed a trembling passenger with the perfect track.',
+          probability: 0.7
+        },
+        {
+          type: 'item',
+          value: 1,
+          description: 'Received a protective mixtape for future rides.',
+          probability: 0.35
+        }
+      ],
+      exceptionNeedAdjustment: -18,
+      followNeedAdjustment: 8,
+      breakNeedAdjustment: 12,
+      violationMessage: 'Breaking the silence invited a chorus of voices you cannot silence.'
     },
     {
       id: 3,
@@ -26,7 +140,53 @@ export const gameData: GameData = {
       description: "Do not accept tips of any kind tonight",
       difficulty: "hard",
       type: "basic",
-      visible: true
+      visible: true,
+      actionKey: 'accept_tip',
+      actionType: 'forbidden',
+      relatedGuidelineId: 1003,
+      defaultSafety: 'safe',
+      defaultOutcome: 'Hard currency keeps cursed favors from binding to you.',
+      exceptions: getExceptions(['cash_intangible_beings']),
+      followConsequences: [
+        {
+          type: 'money',
+          value: 15,
+          description: 'Collected predictable, clean payments.',
+          probability: 0.9
+        }
+      ],
+      breakConsequences: [
+        {
+          type: 'death',
+          value: 1,
+          description: 'A cursed coin latched onto your lifeline.',
+          probability: 0.5
+        },
+        {
+          type: 'reputation',
+          value: -10,
+          description: 'Word spread that you accept forbidden currency.',
+          probability: 0.6
+        }
+      ],
+      exceptionRewards: [
+        {
+          type: 'reputation',
+          value: 7,
+          description: 'Offered charity to a soul who could not pay otherwise.',
+          probability: 0.65
+        },
+        {
+          type: 'story_unlock',
+          value: 1,
+          description: 'Unlocked a spectral favor redeemable later in the night.',
+          probability: 0.45
+        }
+      ],
+      exceptionNeedAdjustment: -12,
+      followNeedAdjustment: 4,
+      breakNeedAdjustment: 14,
+      violationMessage: 'That payment was never meant for mortal hands. It stains everything it touches.'
     },
     {
       id: 4,
@@ -34,7 +194,53 @@ export const gameData: GameData = {
       description: "Keep all windows closed at all times",
       difficulty: "medium",
       type: "basic",
-      visible: true
+      visible: true,
+      actionKey: 'open_window',
+      actionType: 'forbidden',
+      relatedGuidelineId: 1009,
+      defaultSafety: 'safe',
+      defaultOutcome: 'Closed windows keep whispers, ash, and hungry winds outside the cab.',
+      exceptions: getExceptions(['windows_suffocation']),
+      followConsequences: [
+        {
+          type: 'survival',
+          value: 1,
+          description: 'Protected the cabin from invasive spirits.',
+          probability: 0.75
+        }
+      ],
+      breakConsequences: [
+        {
+          type: 'death',
+          value: 1,
+          description: 'The gale carried something inside that never left.',
+          probability: 0.5
+        },
+        {
+          type: 'fuel',
+          value: -3,
+          description: 'Air drag cut into your efficiency.',
+          probability: 0.6
+        }
+      ],
+      exceptionRewards: [
+        {
+          type: 'reputation',
+          value: 9,
+          description: 'Saved a suffocating passenger by cracking the seal just in time.',
+          probability: 0.7
+        },
+        {
+          type: 'item',
+          value: 1,
+          description: 'Received a sunlight talisman for your compassion.',
+          probability: 0.4
+        }
+      ],
+      exceptionNeedAdjustment: -20,
+      followNeedAdjustment: 6,
+      breakNeedAdjustment: 16,
+      violationMessage: 'You opened the cab to the storm and something new rode with you.'
     },
     {
       id: 5,
@@ -42,7 +248,53 @@ export const gameData: GameData = {
       description: "Do not deviate from GPS route for any reason",
       difficulty: "hard",
       type: "basic",
-      visible: true
+      visible: true,
+      actionKey: 'take_shortcut',
+      actionType: 'forbidden',
+      relatedGuidelineId: 1010,
+      defaultSafety: 'safe',
+      defaultOutcome: 'Following dispatch routes minimizes ambush chances and keeps dispatch happy.',
+      exceptions: getExceptions(['shortcut_time_critical']),
+      followConsequences: [
+        {
+          type: 'time',
+          value: -5,
+          description: 'Arrived on schedule without raising suspicion.',
+          probability: 0.8
+        }
+      ],
+      breakConsequences: [
+        {
+          type: 'death',
+          value: 1,
+          description: 'The shortcut led you straight into a supernatural trap.',
+          probability: 0.3
+        },
+        {
+          type: 'fuel',
+          value: -10,
+          description: 'You burned fuel retracing your route through cursed alleys.',
+          probability: 0.6
+        }
+      ],
+      exceptionRewards: [
+        {
+          type: 'money',
+          value: 25,
+          description: 'Passenger tipped big for getting them to safety in time.',
+          probability: 0.7
+        },
+        {
+          type: 'reputation',
+          value: 10,
+          description: 'Earned trust among nocturnal regulars for decisive driving.',
+          probability: 0.65
+        }
+      ],
+      exceptionNeedAdjustment: -30,
+      followNeedAdjustment: 12,
+      breakNeedAdjustment: 18,
+      violationMessage: 'Dispatch routes exist for a reason. The shadows were waiting off-grid.'
     },
     
     // Conditional rules (only apply in certain situations)
@@ -230,6 +482,47 @@ export const gameData: GameData = {
       deceptionLevel: 0.1,
       stressLevel: 0.7,
       trustRequired: 0.3,
+      stateProfile: {
+        needType: 'loneliness',
+        initialLevel: 45,
+        thresholds: {
+          warning: 60,
+          critical: 80,
+          meltdown: 92
+        },
+        needChange: {
+          passive: 4,
+          obey: 8,
+          break: 2,
+          exceptionRelief: 28
+        },
+        exceptionId: 'eye_contact_lonely',
+        tellIntensities: {
+          warning: ['moderate'],
+          critical: ['obvious']
+        },
+        dialogueByStage: {
+          warning: [
+            'Please... could you just look at me for a moment?',
+            'It gets so cold when no one sees me.'
+          ],
+          critical: [
+            'Why won\'t you acknowledge me? I\'m right here!',
+            'If you keep ignoring me I might fade entirely.'
+          ],
+          meltdown: [
+            'Look at me! I refuse to disappear again!'
+          ]
+        },
+        confidenceImpact: {
+          warning: -0.05,
+          critical: -0.1
+        },
+        trustImpact: {
+          warning: 0.05,
+          critical: 0.1
+        }
+      },
       routePreferences: [
         {
           route: 'normal',
@@ -285,6 +578,64 @@ export const gameData: GameData = {
       relationships: [4],
       backstoryUnlocked: false,
       backstoryDetails: "Jake works the night shift at a blood bank, though his employment records don't seem to exist...",
+      tells: [
+        {
+          type: 'behavioral',
+          intensity: 'moderate',
+          description: 'Checks his watch every minute as hunger builds',
+          animationCue: 'frantic_watch_check',
+          reliability: 0.7
+        },
+        {
+          type: 'verbal',
+          intensity: 'obvious',
+          description: 'Mutters about needing to feed soon',
+          triggerPhrase: 'I need to feed',
+          reliability: 0.85
+        }
+      ],
+      guidelineExceptions: ['shortcut_time_critical'],
+      stateProfile: {
+        needType: 'hunger',
+        initialLevel: 55,
+        thresholds: {
+          warning: 65,
+          critical: 82,
+          meltdown: 96
+        },
+        needChange: {
+          passive: 5,
+          obey: 11,
+          break: 3,
+          exceptionRelief: 35
+        },
+        exceptionId: 'shortcut_time_critical',
+        tellIntensities: {
+          warning: ['moderate'],
+          critical: ['obvious']
+        },
+        dialogueByStage: {
+          warning: [
+            'We really should pick up the pace... daylight is unforgiving.',
+            'I can feel the hunger gnawing. Please, a faster route.'
+          ],
+          critical: [
+            'If we don\'t hurry I might lose control.',
+            'The thirst is unbearable. Take the alleys—now.'
+          ],
+          meltdown: [
+            'Too late. I can\'t promise your safety any longer!'
+          ]
+        },
+        confidenceImpact: {
+          warning: -0.08,
+          critical: -0.12
+        },
+        trustImpact: {
+          warning: 0.05,
+          critical: 0.1
+        }
+      },
       routePreferences: [
         {
           route: 'police',
@@ -359,7 +710,40 @@ export const gameData: GameData = {
       guidelineExceptions: ["gps_passenger_warning"],
       deceptionLevel: 0.2,
       stressLevel: 0.8,
-      trustRequired: 0.4
+      trustRequired: 0.4,
+      stateProfile: {
+        needType: 'fear',
+        initialLevel: 50,
+        thresholds: {
+          warning: 65,
+          critical: 83,
+          meltdown: 94
+        },
+        needChange: {
+          passive: 6,
+          obey: 9,
+          break: 4,
+          exceptionRelief: 24
+        },
+        exceptionId: 'gps_passenger_warning',
+        tellIntensities: {
+          warning: ['moderate'],
+          critical: ['obvious']
+        },
+        dialogueByStage: {
+          warning: [
+            'Please, avoid the main roads—they know those paths.',
+            'They watch the highways. Take the back roads, I beg you.'
+          ],
+          critical: [
+            'If you follow the GPS we are dead. Turn now!',
+            'I can hear them in the wires. We have to change course!'
+          ],
+          meltdown: [
+            'Too late—they found us through the lights!'
+          ]
+        }
+      }
     },
     {
       id: 4,

--- a/frontend/src/data/guidelineData.ts
+++ b/frontend/src/data/guidelineData.ts
@@ -54,7 +54,8 @@ export const guidelineData: Guideline[] = [
         ],
         breakingSafer: true,
         description: "Lonely passengers need acknowledgment or they become hostile",
-        probability: 0.3
+        probability: 0.3,
+        requiredStage: 'warning'
       }
     ],
     followConsequences: [
@@ -71,6 +72,20 @@ export const guidelineData: Guideline[] = [
         value: 1,
         description: "Made eye contact - face twisted into void",
         probability: 0.7
+      }
+    ],
+    exceptionRewards: [
+      {
+        type: 'reputation',
+        value: 8,
+        description: 'Acknowledged a lonely spirit with compassion.',
+        probability: 0.75
+      },
+      {
+        type: 'story_unlock',
+        value: 1,
+        description: 'Unlocked a new memory from the restless passenger.',
+        probability: 0.5
       }
     ]
   },
@@ -121,7 +136,8 @@ export const guidelineData: Guideline[] = [
         ],
         breakingSafer: true,
         description: "Passenger knows of supernatural danger on the GPS route",
-        probability: 0.4
+        probability: 0.4,
+        requiredStage: 'warning'
       }
     ],
     followConsequences: [
@@ -144,6 +160,20 @@ export const guidelineData: Guideline[] = [
         value: 1,
         description: "Supernatural ambush on unknown route",
         probability: 0.3
+      }
+    ],
+    exceptionRewards: [
+      {
+        type: 'reputation',
+        value: 10,
+        description: 'Proved you can read the signs and save passengers in danger.',
+        probability: 0.7
+      },
+      {
+        type: 'money',
+        value: 20,
+        description: 'Passenger doubled the fare in gratitude for the detour.',
+        probability: 0.6
       }
     ]
   },
@@ -194,7 +224,8 @@ export const guidelineData: Guideline[] = [
         ],
         breakingSafer: true,
         description: "Ghosts can't handle physical currency - refusing their payment angers them",
-        probability: 0.25
+        probability: 0.25,
+        requiredStage: 'warning'
       }
     ],
     followConsequences: [
@@ -212,9 +243,119 @@ export const guidelineData: Guideline[] = [
         description: "Cursed payment drained your life force",
         probability: 0.5
       }
+    ],
+    exceptionRewards: [
+      {
+        type: 'reputation',
+        value: 7,
+        description: 'Offered grace to a spirit who could not pay.',
+        probability: 0.65
+      },
+      {
+        type: 'story_unlock',
+        value: 1,
+        description: 'Gained a favor redeemable with the spectral community.',
+        probability: 0.45
+      }
     ]
   },
-  
+
+  {
+    id: 1011,
+    title: "Maintain Broadcast Silence",
+    description: "Keep the cab silent to avoid tuning into supernatural frequencies",
+    difficulty: 'easy',
+    type: 'basic',
+    visible: true,
+    isGuideline: true,
+    defaultSafety: 'safe',
+    actionKey: 'play_music',
+    actionType: 'forbidden',
+    exceptions: [
+      {
+        id: 'silent_soothing_song',
+        passengerTypes: ['Insomniac medium with restless spirits', 'Teenage banshee with stage fright'],
+        conditions: [
+          {
+            type: 'passenger_dialogue',
+            value: 'music',
+            operator: 'contains',
+            description: 'Passenger pleads for calming music'
+          },
+          {
+            type: 'passenger_behavior',
+            value: 0.65,
+            operator: 'greater_than',
+            description: 'Stress level high enough to risk an outburst'
+          }
+        ],
+        tells: [
+          {
+            type: 'verbal',
+            intensity: 'obvious',
+            description: "Please—just a soft song before I scream", 
+            triggerPhrase: 'soft song',
+            reliability: 0.85
+          },
+          {
+            type: 'behavioral',
+            intensity: 'moderate',
+            description: 'Passenger rocks back and forth gripping the seat',
+            animationCue: 'rocking_panic',
+            reliability: 0.7
+          },
+          {
+            type: 'verbal',
+            intensity: 'subtle',
+            description: 'Hums the first few notes of a lullaby under their breath',
+            audioCue: 'hummed_lullaby',
+            reliability: 0.6
+          }
+        ],
+        breakingSafer: true,
+        description: 'Certain passengers need a calming melody to keep their powers in check',
+        probability: 0.3,
+        requiredStage: 'warning'
+      }
+    ],
+    followConsequences: [
+      {
+        type: 'survival',
+        value: 1,
+        description: 'Silence kept the radio ghouls asleep',
+        probability: 0.8
+      }
+    ],
+    breakConsequences: [
+      {
+        type: 'death',
+        value: 1,
+        description: 'Amplified whispers lured something terrible into the cab',
+        probability: 0.4
+      },
+      {
+        type: 'fuel',
+        value: -5,
+        description: 'Interference with onboard systems drained power',
+        probability: 0.5
+      }
+    ],
+    exceptionRewards: [
+      {
+        type: 'reputation',
+        value: 6,
+        description: 'Known as the driver who keeps nervous passengers steady',
+        probability: 0.7
+      },
+      {
+        type: 'item',
+        value: 1,
+        description: 'Passenger gifts you a charm that tunes out hostile frequencies',
+        probability: 0.35
+      }
+    ]
+  },
+
   {
     id: 1004,
     title: "Never Speak First",
@@ -266,7 +407,8 @@ export const guidelineData: Guideline[] = [
         ],
         breakingSafer: true,
         description: "Nervous passengers need conversation to prevent violent breakdown",
-        probability: 0.35
+        probability: 0.35,
+        requiredStage: 'warning'
       }
     ],
     followConsequences: [
@@ -283,6 +425,14 @@ export const guidelineData: Guideline[] = [
         value: 1,
         description: "Breaking silence attracted something hostile",
         probability: 0.4
+      }
+    ],
+    exceptionRewards: [
+      {
+        type: 'reputation',
+        value: 6,
+        description: 'Talked a passenger down from the brink.',
+        probability: 0.65
       }
     ]
   },
@@ -332,7 +482,8 @@ export const guidelineData: Guideline[] = [
         ],
         breakingSafer: true,
         description: "Some passengers have legitimate emergency needs",
-        probability: 0.2
+        probability: 0.2,
+        requiredStage: 'critical'
       }
     ],
     followConsequences: [
@@ -348,6 +499,14 @@ export const guidelineData: Guideline[] = [
         type: 'death',
         value: 1,
         description: "Something caught up while stopped",
+        probability: 0.6
+      }
+    ],
+    exceptionRewards: [
+      {
+        type: 'reputation',
+        value: 9,
+        description: 'Trusted the emergency and saved your passenger.',
         probability: 0.6
       }
     ]
@@ -399,7 +558,8 @@ export const guidelineData: Guideline[] = [
         ],
         breakingSafer: true,
         description: "Some passengers genuinely need air or sunlight protection",
-        probability: 0.15
+        probability: 0.15,
+        requiredStage: 'critical'
       }
     ],
     followConsequences: [
@@ -416,6 +576,20 @@ export const guidelineData: Guideline[] = [
         value: 1,
         description: "Spirits entered through open window",
         probability: 0.5
+      }
+    ],
+    exceptionRewards: [
+      {
+        type: 'reputation',
+        value: 9,
+        description: 'Spared a passenger from suffocating in the sealed cab.',
+        probability: 0.7
+      },
+      {
+        type: 'item',
+        value: 1,
+        description: 'Received a sunlight talisman for your empathy.',
+        probability: 0.4
       }
     ]
   },

--- a/frontend/src/hooks/useGameState.ts
+++ b/frontend/src/hooks/useGameState.ts
@@ -5,6 +5,7 @@ import { STORAGE_KEYS, GAME_CONSTANTS, SCREENS, GAME_PHASES } from '../data/cons
 import { ReputationService } from '../services/reputationService';
 import { GameEngine } from '../services/gameEngine';
 import { PassengerService } from '../services/passengerService';
+import { PassengerStateMachine } from '../services/passengerStateMachine';
 import { SaveGameService } from '../services/storageService';
 import { WeatherService } from '../services/weatherService';
 import { gameData } from '../data/gameData';
@@ -40,7 +41,10 @@ const getInitialGameState = (): GameState => {
     // Route mastery and consequence tracking
     routeMastery: { normal: 0, shortcut: 0, scenic: 0, police: 0 },
     routeConsequences: [],
-    consecutiveRouteStreak: { type: '', count: 0 }
+    consecutiveRouteStreak: { type: '', count: 0 },
+    detectedTells: [],
+    ruleConfidence: 0.5,
+    currentPassengerNeedState: null
   };
 };
 
@@ -203,6 +207,8 @@ export const useGameState = (playerStats: PlayerStats) => {
       gameState.timeOfDay
     );
     
+    const passengerNeedState = PassengerStateMachine.initialize(passenger);
+
     setGameState(prev => ({
       ...prev,
       currentPassenger: passenger,
@@ -212,7 +218,9 @@ export const useGameState = (playerStats: PlayerStats) => {
       currentRules: [
         ...prev.currentRules,
         ...gameData.shift_rules.filter(rule => weatherTriggeredRules.includes(rule.id))
-      ]
+      ],
+      currentPassengerNeedState: passengerNeedState,
+      detectedTells: prev.detectedTells || []
     }));
   };
 

--- a/frontend/src/services/gameEngine.ts
+++ b/frontend/src/services/gameEngine.ts
@@ -58,7 +58,16 @@ export class GameEngine {
       visible: guideline.visible,
       conflictsWith: guideline.conflictsWith,
       trigger: guideline.trigger,
-      violationMessage: guideline.violationMessage
+      violationMessage: guideline.violationMessage,
+      actionKey: guideline.actionKey,
+      actionType: guideline.actionType,
+      defaultSafety: guideline.defaultSafety,
+      defaultOutcome: guideline.defaultOutcome,
+      exceptions: guideline.exceptions,
+      followConsequences: guideline.followConsequences,
+      breakConsequences: guideline.breakConsequences,
+      exceptionRewards: guideline.exceptionRewards,
+      relatedGuidelineId: guideline.id
     }));
     
     return {

--- a/frontend/src/services/passengerStateMachine.ts
+++ b/frontend/src/services/passengerStateMachine.ts
@@ -1,0 +1,175 @@
+import type {
+  DetectedTell,
+  Passenger,
+  PassengerNeedStage,
+  PassengerNeedState,
+  PassengerStateProfile,
+  PassengerTell,
+  RuleEvaluationResult
+} from '../types/game';
+
+interface TriggeredTell {
+  tell: PassengerTell;
+  stage: PassengerNeedStage;
+  exceptionId?: string;
+  relatedGuidelineId?: number;
+}
+
+const STAGE_ORDER: Record<PassengerNeedStage, number> = {
+  calm: 0,
+  warning: 1,
+  critical: 2,
+  meltdown: 3
+};
+
+const DEFAULT_TELL_INTENSITIES: Record<PassengerNeedStage, Array<'subtle' | 'moderate' | 'obvious'>> = {
+  calm: ['subtle'],
+  warning: ['moderate'],
+  critical: ['obvious'],
+  meltdown: ['obvious']
+};
+
+const clamp = (value: number, min: number, max: number): number => Math.max(min, Math.min(max, value));
+
+export class PassengerStateMachine {
+  static initialize(passenger: Passenger | null): PassengerNeedState | null {
+    if (!passenger?.stateProfile) return null;
+
+    const profile = passenger.stateProfile;
+    const stage = this.calculateStage(profile.initialLevel, profile.thresholds);
+
+    return {
+      passengerId: passenger.id,
+      needType: profile.needType,
+      level: clamp(profile.initialLevel, 0, 100),
+      stage,
+      stability: this.calculateStability(profile.initialLevel),
+      lastUpdated: Date.now(),
+      revealedStages: stage === 'calm' ? {} : { [stage]: true },
+      profile
+    };
+  }
+
+  static applyRouteChoice(
+    state: PassengerNeedState | null,
+    passenger: Passenger | null,
+    routeChoice: 'normal' | 'shortcut' | 'scenic' | 'police',
+    ruleOutcome?: RuleEvaluationResult | null
+  ): { state: PassengerNeedState | null; triggeredTells: TriggeredTell[] } {
+    if (!state || !passenger?.stateProfile) {
+      return { state, triggeredTells: [] };
+    }
+
+    const profile = passenger.stateProfile;
+
+    let level = state.level + (profile.needChange.passive || 0);
+
+    if (routeChoice === 'shortcut') {
+      level += profile.needChange.break || 0;
+    } else {
+      level += profile.needChange.obey || 0;
+    }
+
+    if (ruleOutcome) {
+      level += ruleOutcome.needAdjustment;
+    }
+
+    level = clamp(level, 0, 100);
+    const stage = this.calculateStage(level, profile.thresholds);
+
+    const triggeredTells = this.collectTells(passenger, state, stage, ruleOutcome);
+
+    const updatedState: PassengerNeedState = {
+      ...state,
+      level,
+      stage,
+      stability: this.calculateStability(level),
+      lastUpdated: Date.now(),
+      revealedStages: {
+        ...state.revealedStages,
+        ...(stage !== 'calm' ? { [stage]: true } : {})
+      }
+    };
+
+    return { state: updatedState, triggeredTells };
+  }
+
+  static getDialogueForStage(passenger: Passenger | null, state: PassengerNeedState | null): string | null {
+    if (!passenger || !state?.profile) return null;
+
+    const profile = state.profile;
+    const lines = profile.dialogueByStage?.[state.stage];
+    if (lines && lines.length > 0) {
+      return lines[Math.floor(Math.random() * lines.length)];
+    }
+
+    return null;
+  }
+
+  static mergeDetectedTells(
+    existing: DetectedTell[] = [],
+    triggered: TriggeredTell[],
+    passengerId: number
+  ): DetectedTell[] {
+    if (triggered.length === 0) return existing;
+
+    const timestamp = Date.now();
+    const merged = triggered.map(trigger => ({
+      tell: trigger.tell,
+      passengerId,
+      detectionTime: timestamp,
+      playerNoticed: false,
+      relatedGuideline: trigger.relatedGuidelineId ?? 0,
+      exceptionId: trigger.exceptionId
+    }));
+
+    return [...existing, ...merged];
+  }
+
+  static isExceptionActive(
+    state: PassengerNeedState | null,
+    exceptionId: string | undefined
+  ): boolean {
+    if (!state || !exceptionId || !state.profile?.exceptionId) return false;
+    return state.profile.exceptionId === exceptionId && STAGE_ORDER[state.stage] >= STAGE_ORDER.warning;
+  }
+
+  private static calculateStage(
+    level: number,
+    thresholds: PassengerStateProfile['thresholds']
+  ): PassengerNeedStage {
+    if (level >= thresholds.meltdown) return 'meltdown';
+    if (level >= thresholds.critical) return 'critical';
+    if (level >= thresholds.warning) return 'warning';
+    return 'calm';
+  }
+
+  private static calculateStability(level: number): number {
+    return clamp(1 - level / 100, 0, 1);
+  }
+
+  private static collectTells(
+    passenger: Passenger,
+    previousState: PassengerNeedState,
+    stage: PassengerNeedStage,
+    ruleOutcome?: RuleEvaluationResult | null
+  ): TriggeredTell[] {
+    if (!passenger.tells || passenger.tells.length === 0) return [];
+
+    const alreadyRevealed = previousState.revealedStages?.[stage];
+    if (alreadyRevealed) return [];
+
+    const intensities = previousState.profile.tellIntensities?.[stage] || DEFAULT_TELL_INTENSITIES[stage];
+
+    const tells = passenger.tells.filter(tell => intensities.includes(tell.intensity));
+
+    if (tells.length === 0) return [];
+
+    return tells.map(tell => ({
+      tell,
+      stage,
+      exceptionId: ruleOutcome?.triggeredException?.id,
+      relatedGuidelineId: ruleOutcome?.rule.relatedGuidelineId
+    }));
+  }
+}


### PR DESCRIPTION
## Summary
- expand shift rule data with action keys, exception metadata, and reward hooks derived from guideline definitions
- add passenger state machine utilities plus state profiles for key riders to drive tells, dialogue, and rule exception triggers
- wire new evaluation logic into driving choices to adjust rule confidence, need meters, and detected tells while surfacing a broadcast-silence guideline

## Testing
- `npm run type-check` *(fails: pre-existing TypeScript lib/config issues surfaced across unrelated modules)*

------
https://chatgpt.com/codex/tasks/task_b_68d64af1e964832187e8006c7705e81c